### PR TITLE
Add Home Assistant add-on support

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,17 @@ docker run --rm \
   --device=/dev/sdb \
   -e COLLECTOR_API_ENDPOINT=http://SCRUTINY_WEB_IPADDRESS:8080 \
   --name hass-security-collector \
-  ghcr.io/analogj/hass-security:master-collector
+ghcr.io/analogj/hass-security:master-collector
 ```
+
+## Home Assistant OS Add-on
+
+Hass-Security can run as a custom add-on for Home Assistant OS.
+
+1. In Home Assistant, open **Settings → Add-ons → Add-on Store**.
+2. Click **Repositories** and add `https://github.com/hass-security/hass-security`.
+3. Locate **Hass-Security** in the store and click **Install**.
+4. Start the add-on and open the ingress link to access the dashboard.
 
 ## Manual Installation (without-Docker)
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,20 @@
+name: Hass-Security
+slug: hass_security
+version: "0.8.1"
+description: Hard drive health dashboard & monitoring
+url: https://github.com/hass-security/hass-security
+startup: services
+boot: auto
+arch:
+  - amd64
+  - armv7
+  - aarch64
+init: false
+ingress: true
+ingress_port: 8080
+ingress_entry: /
+panel_icon: mdi:harddisk
+ports:
+  8080/tcp: 8080
+  8086/tcp: 8086
+command: hass-security start


### PR DESCRIPTION
## Summary
- add `config.yaml` for Home Assistant add-on
- document Home Assistant OS installation steps

## Testing
- `go test ./...` *(fails: forbidden to download modules)*

------
https://chatgpt.com/codex/tasks/task_e_6847bb63c26883309dc7e0fe93d719c4