### PR TITLE
Update binary names and paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ docker run -it --rm -p 8080:8080 \
 ghcr.io/analogj/scrutiny:master-omnibus
 
 # in another terminal trigger the collector
-docker exec scrutiny scrutiny-collector-metrics run
+docker exec scrutiny hass-security-collector-metrics run
 ```
 
 The log files will be available on your host in the `config` directory. Please attach them to this issue. 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,5 +110,5 @@ jobs:
         with:
           name: binaries-${{ matrix.cfg.on }}-${{ matrix.cfg.goos }}-${{ matrix.cfg.goarch }}-${{ matrix.cfg.goarm || 'na' }}.zip
           path: |
-            scrutiny-web-*
-            scrutiny-collector-metrics-*
+            hass-security-web-*
+            hass-security-collector-metrics-*

--- a/.github/workflows/release-frontend.yaml
+++ b/.github/workflows/release-frontend.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           apt-get update && apt-get install -y make
           make binary-frontend
-          tar -czf scrutiny-web-frontend.tar.gz dist
+          tar -czf hass-security-web-frontend.tar.gz dist
       - name: Upload Frontend Asset
         id: upload-release-asset3
         uses: actions/upload-release-asset@v1
@@ -29,6 +29,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SCRUTINY_GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: './scrutiny-web-frontend.tar.gz'
-          asset_name: scrutiny-web-frontend.tar.gz
+          asset_path: './hass-security-web-frontend.tar.gz'
+          asset_name: hass-security-web-frontend.tar.gz
           asset_content_type: application/gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -105,8 +105,8 @@ jobs:
         with:
           name: binaries.zip
           path: |
-            scrutiny-web-*
-            scrutiny-collector-metrics-*
+            hass-security-web-*
+            hass-security-collector-metrics-*
 
   release-publish:
     name: Publish Release
@@ -134,23 +134,23 @@ jobs:
         with:
           version_metadata_path: ${{ github.event.inputs.version_metadata_path }}
           upload_assets:
-            scrutiny-collector-metrics-darwin-amd64
-            scrutiny-collector-metrics-darwin-arm64
-            scrutiny-collector-metrics-freebsd-amd64
-            scrutiny-collector-metrics-linux-amd64
-            scrutiny-collector-metrics-linux-arm-5
-            scrutiny-collector-metrics-linux-arm-6
-            scrutiny-collector-metrics-linux-arm-7
-            scrutiny-collector-metrics-linux-arm64
-            scrutiny-collector-metrics-windows-amd64.exe
-            scrutiny-collector-metrics-windows-arm64.exe
-            scrutiny-web-darwin-amd64
-            scrutiny-web-darwin-arm64
-            scrutiny-web-freebsd-amd64
-            scrutiny-web-linux-amd64
-            scrutiny-web-linux-arm-5
-            scrutiny-web-linux-arm-6
-            scrutiny-web-linux-arm-7
-            scrutiny-web-linux-arm64
-            scrutiny-web-windows-amd64.exe
-            scrutiny-web-windows-arm64.exe
+            hass-security-collector-metrics-darwin-amd64
+            hass-security-collector-metrics-darwin-arm64
+            hass-security-collector-metrics-freebsd-amd64
+            hass-security-collector-metrics-linux-amd64
+            hass-security-collector-metrics-linux-arm-5
+            hass-security-collector-metrics-linux-arm-6
+            hass-security-collector-metrics-linux-arm-7
+            hass-security-collector-metrics-linux-arm64
+            hass-security-collector-metrics-windows-amd64.exe
+            hass-security-collector-metrics-windows-arm64.exe
+            hass-security-web-darwin-amd64
+            hass-security-web-darwin-arm64
+            hass-security-web-freebsd-amd64
+            hass-security-web-linux-amd64
+            hass-security-web-linux-arm-5
+            hass-security-web-linux-arm-6
+            hass-security-web-linux-arm-7
+            hass-security-web-linux-arm64
+            hass-security-web-windows-amd64.exe
+            hass-security-web-windows-arm64.exe

--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,9 @@ fabric.properties
 scrutiny.db
 /dist/
 vendor
-/scrutiny
-/scrutiny-collector-metrics-*
-/scrutiny-web-*
+/hass-security
+/hass-security-collector-metrics-*
+/hass-security-web-*
 scrutiny-*.db
 scrutiny_test.db
 scrutiny.yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Depending on the functionality you are adding, you may need to setup a developme
 # Modifying the Scrutiny Backend Server (API)
 
 1. install the [Go runtime](https://go.dev/doc/install) (v1.20+)
-2. download the `scrutiny-web-frontend.tar.gz` for
+2. download the `hass-security-web-frontend.tar.gz` for
    the [latest release](https://github.com/hass-security/hass-security/releases/latest). Extract to a folder named `dist`
 3. create a `scrutiny.yaml` config file
     ```yaml
@@ -168,7 +168,7 @@ docker run -it --rm -p 8080:8080 \
 --device=/dev/sda \
 --device=/dev/sdb \
 ghcr.io/analogj/scrutiny:master-omnibus
-/opt/hass-security/bin/scrutiny-collector-metrics run
+/opt/hass-security/bin/hass-security-collector-metrics run
 ```
 
 

--- a/collector/cmd/collector-metrics/collector-metrics.go
+++ b/collector/cmd/collector-metrics/collector-metrics.go
@@ -58,8 +58,8 @@ OPTIONS:
 `
 
 	app := &cli.App{
-		Name:     "scrutiny-collector-metrics",
-		Usage:    "smartctl data collector for scrutiny",
+		Name:     "hass-security-collector-metrics",
+		Usage:    "smartctl data collector for hass-security",
 		Version:  version.VERSION,
 		Compiled: time.Now(),
 		Authors: []*cli.Author{
@@ -97,7 +97,7 @@ OPTIONS:
 		Commands: []*cli.Command{
 			{
 				Name:  "run",
-				Usage: "Run the scrutiny smartctl metrics collector",
+				Usage: "Run the hass-security smartctl metrics collector",
 				Action: func(c *cli.Context) error {
 					if c.IsSet("config") {
 						err = config.ReadConfig(c.String("config")) // Find and read the config file
@@ -121,7 +121,7 @@ OPTIONS:
 					}
 
 					if c.IsSet("api-endpoint") {
-						//if the user is providing an api-endpoint with a basepath (eg. http://localhost:8080/scrutiny),
+						//if the user is providing an api-endpoint with a basepath (eg. http://localhost:8080/hass-security),
 						//we need to ensure the basepath has a trailing slash, otherwise the url.Parse() path concatenation doesnt work.
 						apiEndpoint := strings.TrimSuffix(c.String("api-endpoint"), "/") + "/"
 						config.Set("api.endpoint", apiEndpoint)

--- a/webapp/backend/cmd/scrutiny/scrutiny.go
+++ b/webapp/backend/cmd/scrutiny/scrutiny.go
@@ -58,7 +58,7 @@ OPTIONS:
 `
 
 	app := &cli.App{
-		Name:     "scrutiny",
+		Name:     "hass-security",
 		Usage:    "WebUI for smartd S.M.A.R.T monitoring",
 		Version:  version.VERSION,
 		Compiled: time.Now(),
@@ -97,7 +97,7 @@ OPTIONS:
 		Commands: []*cli.Command{
 			{
 				Name:  "start",
-				Usage: "Start the scrutiny server",
+				Usage: "Start the hass-security server",
 				Action: func(c *cli.Context) error {
 					fmt.Fprintln(c.App.Writer, c.Command.Usage)
 					if c.IsSet("config") {

--- a/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
+++ b/webapp/frontend/src/app/modules/dashboard/dashboard.component.html
@@ -129,7 +129,7 @@
             devices and collecting S.M.A.R.T data on a configurable schedule.</p>
 
         <p><br/>You can trigger the Collector manually by running the following command, then refreshing this page:</p>
-        <code>scrutiny-collector-metrics run</code>
+        <code>hass-security-collector-metrics run</code>
 
     </div>
 </ng-template>


### PR DESCRIPTION
## Summary
- switch artifact patterns in GitHub workflows to use `hass-security` binary names
- update docs and gitignore to reference new binaries
- rename CLI binaries in source code

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847bda936288330bc1b8d78e9293c4a