### PR TITLE
Fix Docker docs references

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -31,7 +31,7 @@ docker run -it --rm -p 8080:8080 \
 -e COLLECTOR_LOG_FILE=/opt/hass-security/config/collector.log \
 -e SCRUTINY_LOG_FILE=/opt/hass-security/config/web.log \
 --name scrutiny \
-ghcr.io/analogj/scrutiny:master-omnibus
+ghcr.io/analogj/hass-security:master-omnibus
 
 # in another terminal trigger the collector
 docker exec scrutiny hass-security-collector-metrics run

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,13 +161,13 @@ docker cp scrutiny:/tmp/web.log web.log
 # Docker Development
 
 ```
-docker build -f docker/Dockerfile . -t chcr.io/analogj/scrutiny:master-omnibus
+docker build -f docker/Dockerfile . -t chcr.io/analogj/hass-security:master-omnibus
 docker run -it --rm -p 8080:8080 \
 -v /run/udev:/run/udev:ro \
 --cap-add SYS_RAWIO \
 --device=/dev/sda \
 --device=/dev/sdb \
-ghcr.io/analogj/scrutiny:master-omnibus
+ghcr.io/analogj/hass-security:master-omnibus
 /opt/hass-security/bin/hass-security-collector-metrics run
 ```
 


### PR DESCRIPTION
## Summary
- update docker documentation to use `analogj/hass-security`

## Testing
- `make binary-test` *(fails: Get https://proxy.golang.org/...: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847bf58c20c83308fc7ca6469d93fd3