### PR TITLE
Remove obsolete scrutiny ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,15 +54,11 @@ fabric.properties
 .idea/httpRequests
 
 
-scrutiny.db
 /dist/
 vendor
 /hass-security
 /hass-security-collector-metrics-*
 /hass-security-web-*
-scrutiny-*.db
-scrutiny_test.db
-scrutiny.yaml
 coverage.txt
 /config
 /influxdb


### PR DESCRIPTION
## Summary
- clean up repository ignore list by removing old `scrutiny` entries

## Testing
- `go test ./...` *(fails: module download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847c23fff348330ad11802d0e7f270d