### PR TITLE
Update InfluxDB org in workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
           DOCKER_INFLUXDB_INIT_MODE: setup
           DOCKER_INFLUXDB_INIT_USERNAME: admin
           DOCKER_INFLUXDB_INIT_PASSWORD: password12345
-          DOCKER_INFLUXDB_INIT_ORG: scrutiny
+          DOCKER_INFLUXDB_INIT_ORG: hass-security
           DOCKER_INFLUXDB_INIT_BUCKET: metrics
           DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: my-super-secret-auth-token
         ports:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
           DOCKER_INFLUXDB_INIT_MODE: setup
           DOCKER_INFLUXDB_INIT_USERNAME: admin
           DOCKER_INFLUXDB_INIT_PASSWORD: password12345
-          DOCKER_INFLUXDB_INIT_ORG: scrutiny
+          DOCKER_INFLUXDB_INIT_ORG: hass-security
           DOCKER_INFLUXDB_INIT_BUCKET: metrics
           DOCKER_INFLUXDB_INIT_ADMIN_TOKEN: my-super-secret-auth-token
         ports:


### PR DESCRIPTION
## Summary
- use new `hass-security` org value for InfluxDB

## Testing
- `make binary-test` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847c2f8f7b483309553af18e0ee1096