### PR TITLE
Fix container name in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,11 +30,11 @@ docker run -it --rm -p 8080:8080 \
 -e DEBUG=true \
 -e COLLECTOR_LOG_FILE=/opt/hass-security/config/collector.log \
 -e SCRUTINY_LOG_FILE=/opt/hass-security/config/web.log \
---name scrutiny \
+--name hass-security \
 ghcr.io/analogj/hass-security:master-omnibus
 
 # in another terminal trigger the collector
-docker exec scrutiny hass-security-collector-metrics run
+docker exec hass-security hass-security-collector-metrics run
 ```
 
 The log files will be available on your host in the `config` directory. Please attach them to this issue. 


### PR DESCRIPTION
## Summary
- fix container name in bug_report.md example

## Testing
- `grep -R "docker exec" -n`

------
https://chatgpt.com/codex/tasks/task_e_6847c3475c3c8330959b1c2c87cc60e8